### PR TITLE
Fix grouping by tag

### DIFF
--- a/costreporter.py
+++ b/costreporter.py
@@ -150,13 +150,14 @@ def get_costs(a, s, rlist, start, end, dims, tags, granularity="MONTHLY"):
     groupbys = []
     if len(dims) > 0 or len(tags) > 0:
         dims = dims.split(",")
-        for d in dims:
-            groupbys.append({"Type":"DIMENSION", "Key":d})
+        if len(dims) > 0 and dims != [""]:
+            for d in dims:
+                groupbys.append({"Type":"DIMENSION", "Key":d})
 
         tags = tags.split(",")
-    if len(tags) > 0 and tags != [""]:
-        for t in tags:
-            groupbys.append({"Type":"TAG", "Key":t})
+        if len(tags) > 0 and tags != [""]:
+            for t in tags:
+                groupbys.append({"Type":"TAG", "Key":t})
 
     if len(groupbys) == 0: # group by service by default
         groupbys.append({"Type":"DIMENSION", "Key":"SERVICE"})


### PR DESCRIPTION
After f5989045c0a1423557febb1e209af35fe2f51179 the `-g` option stopped working, giving this error:
```
ERROR: exception region=us-east-1, error=(<class 'botocore.exceptions.ClientError'>, ClientError(u'An error occurred (ValidationException) when calling the GetCostAndUsage operation: Group Definition is invalid. Both type an key need to be set to a non-empty value.',), <traceback object at 0x10f0ba1b8>)
```

There was an if check that was removed, which caused GroupBy to get both a Tag and Dimension grouping, with the Dimension being an empty string.  This change fixes the problem.